### PR TITLE
[Bugfix] Added missing AuthenticationFailedException

### DIFF
--- a/src/Exception/AuthenticationFailedException.php
+++ b/src/Exception/AuthenticationFailedException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ApiVideo\Client\Exception;
+
+class AuthenticationFailedException extends \Exception implements ExceptionInterface
+{
+
+}


### PR DESCRIPTION
Fixes a bug discovered with our project tests :
```

ErrorException: Attempted to load class "AuthenticationFailedException" from namespace "ApiVideo\Client".
Did you forget a "use" statement for another namespace? in <project-path>\vendor\api-video\php-api-client\src\BaseClient.php:211

```